### PR TITLE
add order products to current order route

### DIFF
--- a/src/models/order.ts
+++ b/src/models/order.ts
@@ -16,8 +16,9 @@ export type OrderProduct = {
 export class OrderStore {
   // get current order by user
   async currentOrder(user_id: number): Promise<Order> {
+    let conn;
     try {
-      const conn = await client.connect();
+       conn = await client.connect();
       const sql = "SELECT * FROM orders WHERE user_id=($1) AND status=($2)";
       const result = await conn.query(sql, [user_id, "active"]);
       let order = result.rows[0];
@@ -34,7 +35,7 @@ export class OrderStore {
       const productsResult = await conn.query(productsSql, [order.id]);
 
 
-      conn.release();
+
       return {
         ...order,
         products: productsResult.rows
@@ -43,6 +44,8 @@ export class OrderStore {
       throw new Error(
         `Could not get current order for user ${user_id}. Error: ${err}`
       );
+    } finally {
+      if (conn) conn.release();
     }
   }
 


### PR DESCRIPTION
This pull request updates the `OrderStore` class in `src/models/order.ts` to enhance the functionality of retrieving an active order for a user by including the associated products in the response.

### Enhancements to order retrieval:
* Modified the `getCurrentOrder` method to fetch and include the products associated with the active order. This involves querying the `order_products` and `products` tables to retrieve product details (e.g., `product_id`, `name`, `price`, `quantity`) and adding them to the returned order object.

This change improves the usability of the `getCurrentOrder` method by providing a more comprehensive view of the active order, including its products.