### PR TITLE
feat: return total price when completing order

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -73,6 +73,7 @@ These are the notes from a meeting with the frontend developer that describe wha
   - `price`
   - `quantity`
   - `image`
+- `total`: total price of all products in the order (returned when order is completed)
 
 #### OrderProduct
 - order_id
@@ -114,4 +115,4 @@ order_products {
 
 - When updating a product's quantity in an order, if the quantity is set to 0 or less, the product will be removed from the order. The API will return a distinct response indicating removal.
 - All order modifications (add/update/remove product) are performed atomically to ensure data consistency.
-- Completing an order will set its status to `complete` and prevent further modifications to that order.
+- Completing an order will set its status to `complete`, return the order with a `total` field, and prevent further modifications to that order.

--- a/src/handlers/orders.ts
+++ b/src/handlers/orders.ts
@@ -21,10 +21,15 @@ const completeCurrentOrder = async (req: Request, res: Response) => {
     const order = await store.completeOrder(user.id);
     res.json(order);
   } catch (err) {
-    if (err instanceof Error && (err.message === "User not authenticated" || err.message === "Order ID is undefined")) {
+    if (
+      err instanceof Error &&
+      (err.message === "User not authenticated" ||
+        err.message === "Order ID is undefined")
+    ) {
       res.status(400).json({ error: err.message });
     } else {
-      res.status(500).json({ error: "An unexpected error occurred", details: (err as Error).message });
+      console.error("Error in completeCurrentOrder:", err);
+      res.status(500).json({ error: "An unexpected error occurred" });
     }
   }
 };

--- a/src/handlers/orders.ts
+++ b/src/handlers/orders.ts
@@ -24,7 +24,7 @@ const completeCurrentOrder = async (req: Request, res: Response) => {
     if (err instanceof Error && (err.message === "User not authenticated" || err.message === "Order ID is undefined")) {
       res.status(400).json({ error: err.message });
     } else {
-      res.status(500).json({ error: "An unexpected error occurred" });
+      res.status(500).json({ error: "An unexpected error occurred", details: (err as Error).message });
     }
   }
 };

--- a/src/models/order.ts
+++ b/src/models/order.ts
@@ -53,7 +53,8 @@ export class OrderStore {
       // Begin transaction
       await conn.query("BEGIN");
       // find the current active order for the user
-      const sql = "SELECT * FROM orders WHERE user_id=($1) AND status=($2) FOR UPDATE";
+      const sql =
+        "SELECT * FROM orders WHERE user_id=($1) AND status=($2) FOR UPDATE";
       const result = await conn.query(sql, [user_id, "active"]);
       const order = result.rows[0];
       if (!order) {
@@ -73,7 +74,7 @@ export class OrderStore {
 
       // Commit transaction
       await conn.query("COMMIT");
-      return {...updatedOrder, totalPrice: total};
+      return { ...updatedOrder, totalPrice: total };
     } catch (err) {
       // Rollback transaction in case of error
       await conn.query("ROLLBACK");

--- a/src/models/order.ts
+++ b/src/models/order.ts
@@ -67,7 +67,7 @@ export class OrderStore {
 
       // calculate total price
       const totalPriceSql =
-        "SELECT SUM(p.price * op.quantity) AS total_price FROM order_products op JOIN products p ON op.product_id = p.id WHERE op.order_id = $1";
+        "SELECT COALESCE(SUM(p.price * op.quantity), 0) AS total_price FROM order_products op JOIN products p ON op.product_id = p.id WHERE op.order_id = $1";
       const totalPriceResult = await conn.query(totalPriceSql, [order.id]);
       const totalPrice = totalPriceResult.rows[0].total_price;
 

--- a/src/models/order.ts
+++ b/src/models/order.ts
@@ -69,11 +69,11 @@ export class OrderStore {
       const totalPriceSql =
         "SELECT COALESCE(SUM(p.price * op.quantity), 0) AS total_price FROM order_products op JOIN products p ON op.product_id = p.id WHERE op.order_id = $1";
       const totalPriceResult = await conn.query(totalPriceSql, [order.id]);
-      const totalPrice = totalPriceResult.rows[0].total_price;
+      const total = totalPriceResult.rows[0].total_price;
 
       // Commit transaction
       await conn.query("COMMIT");
-      return {...updatedOrder, totalPrice};
+      return {...updatedOrder, totalPrice: total};
     } catch (err) {
       // Rollback transaction in case of error
       await conn.query("ROLLBACK");


### PR DESCRIPTION
This pull request introduces changes to enhance the handling of order completion by adding a `total` field to represent the total price of all products in an order. The changes ensure that the `total` is calculated and returned as part of the order data, improving the API's functionality and consistency.

### Updates to API Requirements:
* Added a `total` field to the `Order` model, representing the total price of all products in the order. This field is returned when the order is completed. (`REQUIREMENTS.md`, [REQUIREMENTS.mdR76](diffhunk://#diff-d79f4c9cbc0e5c8a55f3b350009d2a15de355cad101286c7c3fc7c9b23ed93d3R76))
* Updated the behavior for completing an order: the API now calculates and includes the `total` field in the response, along with setting the order's status to `complete` and preventing further modifications. (`REQUIREMENTS.md`, [REQUIREMENTS.mdL117-R118](diffhunk://#diff-d79f4c9cbc0e5c8a55f3b350009d2a15de355cad101286c7c3fc7c9b23ed93d3L117-R118))

### Backend Implementation:
* Modified the `OrderStore` class to calculate the total price of all products in an order by querying the database. The calculated `totalPrice` is included in the returned order object when the order is completed. (`src/models/order.ts`, [src/models/order.tsR67-R76](diffhunk://#diff-5d9463e24eeae191990db04863337ddce3bf76f873ec9be0a2d00f8d03a2a3dfR67-R76))